### PR TITLE
feat: 유저 조회 기능 구현

### DIFF
--- a/src/boss-raid/boss-raid.controller.ts
+++ b/src/boss-raid/boss-raid.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-} from '@nestjs/common';
+import { Controller, Get, Post, Body } from '@nestjs/common';
 import { BossRaidService } from './boss-raid.service';
 import { EnterBossRaidDto } from './dto/enter-boss-raid.dto';
 

--- a/src/boss-raid/entities/boss-raid.entity.ts
+++ b/src/boss-raid/entities/boss-raid.entity.ts
@@ -1,1 +1,0 @@
-export class BossRaid {}

--- a/src/boss-raid/entities/bossRaidHistory.entity.ts
+++ b/src/boss-raid/entities/bossRaidHistory.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+@Entity()
+export class BossRaidHistory {
+  @PrimaryGeneratedColumn()
+  raidRecordId: number;
+
+  @Column()
+  score: number;
+
+  @Column({
+    type: 'datetime',
+  })
+  enterTime: Date;
+
+  @Column({
+    type: 'datetime',
+    nullable: false,
+  })
+  endTime: Date;
+
+  @ManyToOne(() => User, (user) => user.bossRaidHistories, {
+    nullable: false,
+  })
+  user: User;
+}

--- a/src/database/redis/redis.module.ts
+++ b/src/database/redis/redis.module.ts
@@ -10,6 +10,7 @@ import { RedisService } from './redis.service';
       useFactory: async (configService: ConfigService) => ({
         store: redisStore,
         host: configService.get('REDIS_HOST'),
+        password: configService.get('REDIS_PASSWORD'),
         port: configService.get('REDIS_PORT'),
         ttl: configService.get('REDIS_TOKEN_EXPIRED_AT'),
       }),

--- a/src/database/sql/typeorm.service.ts
+++ b/src/database/sql/typeorm.service.ts
@@ -17,6 +17,7 @@ export class TypeOrmService implements TypeOrmOptionsFactory {
       database: this.configService.get('DB_NAME'),
       namingStrategy: new SnakeNamingStrategy(),
       entities: [__dirname + '/../../**/**/*.entity{.ts,.js}'],
+      timezone: this.configService.get('DB_TIMEZONE'),
       synchronize: this.configService.isEnv('development'),
       logging: this.configService.isEnv('development'),
     };

--- a/src/user/dto/find-user.dto.ts
+++ b/src/user/dto/find-user.dto.ts
@@ -1,0 +1,15 @@
+import { IsNumber } from 'class-validator';
+import { BossRaidHistory } from '../../boss-raid/entities/bossRaidHistory.entity';
+import { User } from '../entities/user.entity';
+
+export class FindUserDto {
+  constructor(user: User) {
+    this.totalScore = user.totalScore;
+    this.bossRaidHistory = user.bossRaidHistories;
+  }
+
+  @IsNumber()
+  readonly totalScore: number;
+
+  readonly bossRaidHistory: BossRaidHistory[];
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { BossRaidHistory } from '../../boss-raid/entities/bossRaidHistory.entity';
 
 @Entity('user')
 export class User {
@@ -7,4 +8,11 @@ export class User {
 
   @Column({ nullable: false, default: 0 })
   totalScore: number;
+
+  @OneToMany(() => BossRaidHistory, (bossRaidHistory) => bossRaidHistory.user, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  bossRaidHistories: BossRaidHistory[];
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { FindUserDto } from './dto/find-user.dto';
 
 @Controller('user')
 export class UserController {
@@ -19,14 +20,14 @@ export class UserController {
     return this.userService.create();
   }
 
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    return new FindUserDto(await this.userService.findOne(+id));
+  }
+
   @Get()
   findAll() {
     return this.userService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.userService.findOne(+id);
   }
 
   @Patch(':id')

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -25,7 +25,10 @@ export class UserService {
   }
 
   async findOne(id: number) {
-    const user = await this.userRepository.findOneBy({ id: id });
+    const user = await this.userRepository.findOne({
+      relations: ['bossRaidHistories'],
+      where: { id: id },
+    });
 
     if (!user) {
       throw new NotFoundException();


### PR DESCRIPTION
- 유저 조회시 bossRaidHistory 엔티티가 필요하므로 bossRaidHistory entity 생성 및 관계 설정(유저 1: bossRaidHistory N)
- [GET] {{BASE_URL}}/user/[userId] 호출시 dto를 거쳐 totalScore와 bossRaidHistory만 반환
- 유저 조회시 dto를 거치는 이유는 userService.findOne() 호출 메서드를 userController 뿐 아니라 bossRaidService에서도 이용하고 있기 때문임
- 결과
![findOneUser](https://user-images.githubusercontent.com/30682847/190893312-4492b8c3-6769-44a9-9e8e-fe89f7e34e78.png)
