### PR TITLE
Feature/10

### DIFF
--- a/src/boss-raid/boss-raid.message.ts
+++ b/src/boss-raid/boss-raid.message.ts
@@ -1,0 +1,8 @@
+export default {
+  NOT_FOUND_RAID: '존재하지 않는 레이드입니다.',
+  NOT_FOUND_CURRENT_RAID:
+    '현재 진행중인 레이드가 없거나 제한 시간이 초과되었습니다.',
+  BAD_REQUEST_USER: '현재 진행중인 레이드의 userId가 입력한 userId와 다릅니다',
+  BAD_REQUEST_RAID:
+    '현재 진행중인 레이드의 raidRecordId가 입력한 raidRecordId와 다릅니다.',
+};

--- a/src/boss-raid/entities/bossRaidHistory.entity.ts
+++ b/src/boss-raid/entities/bossRaidHistory.entity.ts
@@ -10,6 +10,10 @@ import { User } from '../../user/entities/user.entity';
 
 @Entity()
 export class BossRaidHistory {
+  constructor(user: User) {
+    this.user = user;
+  }
+
   @PrimaryGeneratedColumn()
   raidRecordId: number;
 


### PR DESCRIPTION
## refactor: BossRaidService의 enter() 메서드 리팩토링
- 상수 currentRaid를 변수 raidInfo로 변경
  - 새로운 값이 입력되기 때문에 Object.assing으로 값을 묶어 객체를 새로 정의
  - 변수명에 currentRaid보다 정보 목적이 강하므로 raidInfo가 더 적절하다고 판단해 변수명 변경
  - currentRaid는 엔티티인 newHistory가 사용(newHistory -> currentRaid)

## refactor: BossRaidService의 end() 메서드 리팩토링
- error 메시지를 따로 boss-raid.message로 빼서 관리
- 이미 enter에서 redis의 currentRaid 데이터에 유효한 userId와 raidId가 들어가기 때문에 데이터베이스에 userId와 raidId가 존재하는지는 검증할 필요 없음
- req.body.userId와 req.body.raidRecordId가 redis currentRaid에 등록된 userId, raidRecordId에 매칭되는지 검증 후 예외 처리하는 로직은 유지