### PR TITLE
feat: 보스레이드 랭킹 조회 구현

### DIFF
--- a/src/boss-raid/boss-raid.controller.ts
+++ b/src/boss-raid/boss-raid.controller.ts
@@ -1,6 +1,10 @@
 import { Controller, Get, Post, Body, Patch } from '@nestjs/common';
 import { BossRaidService } from './boss-raid.service';
-import { EndBossRaidRequestDto, EnterBossRaidRequestDto } from './dto';
+import {
+  EndBossRaidRequestDto,
+  EnterBossRaidRequestDto,
+  TopRankerListRequestDto,
+} from './dto';
 
 @Controller('boss-raid')
 export class BossRaidController {
@@ -9,6 +13,11 @@ export class BossRaidController {
   @Get('')
   findRaidStatus() {
     return this.bossRaidService.findRaidStatus();
+  }
+
+  @Post('/top-ranker-list')
+  findTopRankerList(@Body() topRankerListDto: TopRankerListRequestDto) {
+    return this.bossRaidService.findTopRankerList(topRankerListDto);
   }
 
   @Post('/enter')

--- a/src/boss-raid/boss-raid.message.ts
+++ b/src/boss-raid/boss-raid.message.ts
@@ -5,4 +5,7 @@ export default {
   BAD_REQUEST_USER: '현재 진행중인 레이드의 userId가 입력한 userId와 다릅니다',
   BAD_REQUEST_RAID:
     '현재 진행중인 레이드의 raidRecordId가 입력한 raidRecordId와 다릅니다.',
+  BAD_REQUEST_ENTER:
+    '이미 입장한 다른 유저가 있습니다. 현재 진행중인 레이드 id: ',
+  BAD_REQUEST_LEVEL_INPUT: '보스레이드에 존재하지 않는 레벨입니다.',
 };

--- a/src/boss-raid/dto/index.ts
+++ b/src/boss-raid/dto/index.ts
@@ -3,3 +3,4 @@ export * from './enter-boss-raid-request.dto';
 export * from './enter-boss-raid-response.dto';
 export * from './end-boss-raid-request.dto';
 export * from './update-boss-raid.dto';
+export * from './top-ranker-list-request.dto';

--- a/src/boss-raid/dto/top-ranker-list-request.dto.ts
+++ b/src/boss-raid/dto/top-ranker-list-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class TopRankerListRequestDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+}

--- a/src/boss-raid/dto/top-ranker-list-response.dto.ts
+++ b/src/boss-raid/dto/top-ranker-list-response.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class TopRankerListResponseDto {
+  ranking: number;
+  userId: number;
+  totalScore: number;
+}

--- a/src/database/redis/redis.service.ts
+++ b/src/database/redis/redis.service.ts
@@ -1,15 +1,19 @@
 import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
-import { Cache } from 'cache-manager';
+import IORedis from 'ioredis';
 
 @Injectable()
 export class RedisService {
+  readonly redisClient: IORedis;
+
   constructor(
     @Inject(CACHE_MANAGER)
-    private readonly cache: Cache
-  ) {}
+    private readonly cache: IORedis
+  ) {
+    this.redisClient = cache;
+  }
 
   async get(key: string): Promise<any> {
-    return await this.cache.get(key);
+    return this.cache.get(key);
   }
 
   async set(key: string, value: any, option?: any): Promise<void> {
@@ -23,4 +27,8 @@ export class RedisService {
   async del(key: string): Promise<void> {
     await this.cache.del(key);
   }
+
+  // async zadd(key: string, score: number, userId: number) {
+  //   await this.cache.zadd(key, score, userId);
+  // }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -8,7 +8,6 @@ import {
   Delete,
 } from '@nestjs/common';
 import { UserService } from './user.service';
-import { UpdateUserDto } from './dto/update-user.dto';
 import { FindUserDto } from './dto/find-user.dto';
 import { CreateUserDto } from './dto/create-user.dto';
 
@@ -24,20 +23,5 @@ export class UserController {
   @Get(':id')
   async findOne(@Param('id') id: string): Promise<FindUserDto | undefined> {
     return new FindUserDto(await this.userService.findOne(+id));
-  }
-
-  @Get()
-  findAll() {
-    return this.userService.findAll();
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.userService.update(+id, updateUserDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.userService.remove(+id);
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,10 +3,11 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { BossRaidHistory } from '../boss-raid/entities/bossRaidHistory.entity';
 
 @Module({
   controllers: [UserController],
   providers: [UserService],
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, BossRaidHistory])],
 })
 export class UserModule {}


### PR DESCRIPTION
## feat: 보스레이드 랭킹 조회 구현

- 보스레이드 totalScore 내림차순으로 랭킹을 조회
- 랭킹 데이터는 웹 서버에 캐싱하거나 레디스에 캐싱하여 구현
```
{{BASE_URL}}/bossRaid/topRankerList

request.body
{
  userId: number;
}

response
{
  topRankerInfoList: RankingInfo[]
  myRankingInfo: RankingInfo
}

interface RankingInfo {
  ranking: number; // 랭킹 1위의 ranking 값은 0입니다.
  userId: number;
  totalScore: number;
}
```